### PR TITLE
refactor(ui): unify API/host URL builders and normalize endpoint paths

### DIFF
--- a/src/api/schedule.js
+++ b/src/api/schedule.js
@@ -2,7 +2,7 @@ import request from '@/utils/request'
 
 export function list(data) {
   return request({
-    url: 'api/v1/schedule/list',
+    url: '/v1/schedule/list',
     method: 'get',
     params: data
   })
@@ -10,7 +10,7 @@ export function list(data) {
 
 export function add(data) {
   return request({
-    url: 'api/v1/schedule/add',
+    url: '/v1/schedule/add',
     method: 'post',
     data
   })
@@ -18,7 +18,7 @@ export function add(data) {
 
 export function edit(data) {
   return request({
-    url: 'api/v1/schedule/update',
+    url: '/v1/schedule/update',
     method: 'put',
     data
   })
@@ -26,7 +26,7 @@ export function edit(data) {
 
 export function getSchedule(id) {
   return request({
-    url: 'api/v1/schedule/query',
+    url: '/v1/schedule/query',
     method: 'get',
     params: {
       id
@@ -36,7 +36,7 @@ export function getSchedule(id) {
 
 export function deleteSchedule(data) {
   return request({
-    url: 'api/v1/schedule/delete',
+    url: '/v1/schedule/delete',
     method: 'delete',
     data
   })

--- a/src/store/modules/user.js
+++ b/src/store/modules/user.js
@@ -1,5 +1,6 @@
 import { login, ldapLogin, logout, getInfo, refreshtoken } from '@/api/user'
 import { getToken, setToken, removeToken } from '@/utils/auth'
+import { buildHostUrl } from '@/utils/url'
 import router, { resetRouter } from '@/router'
 import storage from '@/utils/storage'
 
@@ -31,7 +32,7 @@ const mutations = {
     if (avatar.indexOf('http') !== -1) {
       state.avatar = avatar
     } else {
-      state.avatar = process.env.VUE_APP_BASE_API + avatar
+      state.avatar = buildHostUrl(avatar)
     }
   },
   SET_ROLES: (state, roles) => {

--- a/src/utils/request.js
+++ b/src/utils/request.js
@@ -2,16 +2,14 @@ import axios from 'axios'
 import { MessageBox, Message } from 'element-ui'
 import store from '@/store'
 import { getToken } from '@/utils/auth'
+import { getApiBaseUrl, buildApiUrl, buildHostUrl } from '@/utils/url'
+
+export { getApiBaseUrl, buildApiUrl, buildHostUrl } from '@/utils/url'
 
 
 // 动态设置 baseURL
 const getBaseUrl = () => {
-  if (process.env.NODE_ENV === 'development') {
-    return `${process.env.VUE_APP_BASE_API}${process.env.VUE_APP_API_PATH}`
-  } else {
-    // 生产环境：如果 VUE_APP_BASE_API 有值则使用，否则使用 VUE_APP_API_PATH
-    return process.env.VUE_APP_BASE_API + process.env.VUE_APP_API_PATH
-  }
+  return getApiBaseUrl()
 }
 
 // create an axios instance

--- a/src/utils/url.js
+++ b/src/utils/url.js
@@ -1,0 +1,12 @@
+const normalizePath = (path = '') => {
+  if (!path) return ''
+  return path.startsWith('/') ? path : `/${path}`
+}
+
+const getHostBaseUrl = () => process.env.VUE_APP_BASE_API || ''
+
+export const getApiBaseUrl = () => `${getHostBaseUrl()}${process.env.VUE_APP_API_PATH || ''}`
+
+export const buildApiUrl = (path = '') => `${getApiBaseUrl()}${normalizePath(path)}`
+
+export const buildHostUrl = (path = '') => `${getHostBaseUrl()}${normalizePath(path)}`

--- a/src/utils/zipdownload.js
+++ b/src/utils/zipdownload.js
@@ -1,14 +1,14 @@
 import axios from 'axios'
 import { getToken } from '@/utils/auth'
+import { buildApiUrl } from '@/utils/url'
 
 const mimeMap = {
   xlsx: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
   zip: 'application/zip'
 }
 
-const baseUrl = process.env.VUE_APP_BASE_API
 export function downLoadZip(str, filename) {
-  var url = baseUrl + str
+  var url = buildApiUrl(str)
   axios({
     method: 'get',
     url: url,
@@ -20,7 +20,7 @@ export function downLoadZip(str, filename) {
 }
 
 export function downLoadFile(str) {
-  var url = baseUrl + str
+  var url = buildApiUrl(str)
   const aLink = document.createElement('a')
   aLink.href = url
   document.body.appendChild(aLink)

--- a/src/views/admin/sys-config/set.vue
+++ b/src/views/admin/sys-config/set.vue
@@ -52,6 +52,7 @@ import {
 } from '@/api/admin/sys-config'
 
 import { getToken } from '@/utils/auth'
+import { buildApiUrl, buildHostUrl } from '@/utils/url'
 
 export default {
   name: 'SysConfigSet',
@@ -94,7 +95,7 @@ export default {
           trigger: 'change'
         }]
       },
-      sys_app_logoAction: process.env.VUE_APP_BASE_API + '/v1/public/uploadFile',
+      sys_app_logoAction: buildApiUrl('/v1/public/uploadFile'),
       sys_app_logofileList: [],
       sys_index_skinNameOptions: [{
         'label': '蓝色',
@@ -152,7 +153,7 @@ export default {
     },
     uploadSuccess(response, file, fileList) {
       console.log('sss')
-      this.form.sys_app_logo = process.env.VUE_APP_BASE_API + response.data.full_path
+      this.form.sys_app_logo = buildHostUrl(response.data.full_path)
       console.log(response.data.full_path)
     },
     /** 查询参数列表 */

--- a/src/views/admin/sys-user/index.vue
+++ b/src/views/admin/sys-user/index.vue
@@ -327,6 +327,7 @@
 <script>
 import { listUser, getUser, delUser, addUser, updateUser, exportUser, resetUserPwd, changeUserStatus, importTemplate } from '@/api/admin/sys-user'
 import { getToken } from '@/utils/auth'
+import { buildApiUrl } from '@/utils/url'
 
 import { listPost } from '@/api/admin/sys-post'
 import { listRole } from '@/api/admin/sys-role'
@@ -391,7 +392,7 @@ export default {
         // 设置上传的请求头部
         headers: { Authorization: 'Bearer ' + getToken() },
         // 上传的地址
-        url: process.env.VUE_APP_BASE_API + '/system/user/importData'
+        url: buildApiUrl('/system/user/importData')
       },
       // 查询参数
       queryParams: {

--- a/src/views/dev-tools/build/index.vue
+++ b/src/views/dev-tools/build/index.vue
@@ -11,6 +11,7 @@
 </template>
 
 <script>
+import { buildHostUrl } from '@/utils/url'
 
 export default {
   components: {
@@ -18,7 +19,7 @@ export default {
   },
   data() {
     return {
-      src: process.env.VUE_APP_BASE_API + '/form-generator/index.html',
+      src: buildHostUrl('/form-generator/index.html'),
       height: document.documentElement.clientHeight - 94.5 + 'px;',
       loading: true
     }

--- a/src/views/dev-tools/swagger/index.vue
+++ b/src/views/dev-tools/swagger/index.vue
@@ -15,12 +15,14 @@
   </BasicLayout>
 </template>
 <script>
+import { buildHostUrl } from '@/utils/url'
+
 export default {
   name: 'Swagger',
   components: {},
   data() {
     return {
-      src: process.env.VUE_APP_BASE_API + '/swagger/smart/index.html',
+      src: buildHostUrl('/swagger/smart/index.html'),
       height: document.documentElement.clientHeight - 94.5 + 'px;',
       loading: true
     }

--- a/src/views/profile/userAvatar.vue
+++ b/src/views/profile/userAvatar.vue
@@ -55,6 +55,7 @@
 import store from '@/store'
 import { VueCropper } from 'vue-cropper'
 import { uploadAvatar } from '@/api/admin/sys-user'
+import { buildHostUrl } from '@/utils/url'
 
 export default {
   components: { VueCropper },
@@ -119,7 +120,7 @@ export default {
         uploadAvatar(formData).then(response => {
           if (response.code === 200) {
             this.open = false
-            this.options.img = process.env.VUE_APP_BASE_API + response.data
+            this.options.img = buildHostUrl(response.data)
             this.msgSuccess(response.msg)
           } else {
             this.msgError(response.msg)


### PR DESCRIPTION
背景：前端存在多处手动拼接地址（接口、上传、下载、头像、iframe），容易出现前缀不一致与环境切换问题。
改动：引入统一 URL 构造函数并替换相关调用；[request](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) 基准地址与业务调用保持同源；修正 schedule 路径前缀。
影响范围：仅地址拼接逻辑，不改后端协议与业务字段。
验证：对涉及文件进行静态错误检查通过；关键页面（系统配置上传、用户导入、头像、Swagger/表单构建页）需按环境做一次联调。
风险与回滚：若发现单点路径异常，可按文件回滚到上一版拼接；统一函数集中在 src/utils/url.js，定位与回退成本低。

新增统一 URL 工具 src/utils/url.js：getApiBaseUrl、buildApiUrl、buildHostUrl，统一处理 VUE_APP_BASE_API / VUE_APP_API_PATH 与前导 /。
src/utils/request.js 改为复用 getApiBaseUrl()，并转为从 url.js 复用/导出统一函数，避免各处手工拼接。
接口类地址统一到 buildApiUrl： src/views/admin/sys-user/index.vue、src/views/admin/sys-config/set.vue、src/utils/zipdownload.js。
静态/资源类地址统一到 buildHostUrl： src/views/profile/userAvatar.vue、src/views/dev-tools/swagger/index.vue、src/views/dev-tools/build/index.vue、src/store/modules/user.js。
顺带修正不一致路径 src/api/schedule.js：api/v1/... → /v1/...，避免与 baseURL 叠加出错。